### PR TITLE
Auto-instantiate forms when type-hinted in route parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /config.yml
 /output/
 /var/
+__pycache__/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,7 @@ from flask_assets import Bundle, Environment
 from flask_login import LoginManager
 from flask_session import Session
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import FlaskForm
 from pydantic import BaseModel as Model
 
 from app.services.config import Config
@@ -29,6 +30,7 @@ from app.services import hier  # noqa: E402
 
 from . import auto_import, data  # noqa: E402
 
+import inspect
 
 class App(flask.Flask):
     def __init__(self):
@@ -147,10 +149,7 @@ class App(flask.Flask):
         and POST methods, useful for form-based routes.
         """
         options.setdefault("methods", ("GET", "POST"))
-        # return super().route(rule, **options)
-        import inspect
-        from flask_wtf import FlaskForm
-        from flask import request
+        
         def decorator(func):
             # Get function signature
             signature = inspect.signature(func)
@@ -162,7 +161,7 @@ class App(flask.Flask):
                     if issubclass(param.annotation, FlaskForm):
                         form_class = param.annotation
                         # Choose data source based on HTTP method
-                        form_data = request.form if request.method == "POST" else request.args
+                        form_data = flask.request.form if flask.request.method == "POST" else flask.request.args
                         form_instance = form_class(form_data)
                         kwargs[name] = form_instance
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,9 +58,7 @@ class App(Flask):
             }
             if without_empty != dict(request.args):
                 return self.redirect(
-                    request.path
-                    + "?"
-                    + urllib.parse.urlencode(without_empty)
+                    request.path + "?" + urllib.parse.urlencode(without_empty)
                 )
 
         self.jinja_env.lstrip_blocks = True

--- a/app/routes/discord.py
+++ b/app/routes/discord.py
@@ -155,7 +155,6 @@ def discord_link_confirm(form: DiscordLinkForm):
             )
             return app.redirect("index")
 
-
     if not form.validate_on_submit():
         return app.render(
             "users/discord_link_confirm",

--- a/app/routes/discord.py
+++ b/app/routes/discord.py
@@ -70,8 +70,8 @@ class DiscordRegisterForm(Form):
 
 
 @app.route("/register/discord/")
-def discord_register():
-    form = DiscordRegisterForm()
+def discord_register(form: DiscordRegisterForm):
+    # form = DiscordRegisterForm()
 
     access_token = flask.session.get("discord_access_token")
     refresh_token = flask.session.get("discord_refresh_token")

--- a/app/routes/discord.py
+++ b/app/routes/discord.py
@@ -71,7 +71,6 @@ class DiscordRegisterForm(Form):
 
 @app.route("/register/discord/")
 def discord_register(form: DiscordRegisterForm):
-    # form = DiscordRegisterForm()
 
     access_token = flask.session.get("discord_access_token")
     refresh_token = flask.session.get("discord_refresh_token")
@@ -135,7 +134,7 @@ def discord_link():
 
 @app.route("/link/discord/confirm/")
 @user_service.authenticated
-def discord_link_confirm():
+def discord_link_confirm(form: DiscordLinkForm):
     if current_user.has_discord:
         flask.flash(ALREADY_LINKED_MESSAGE, "error")
         return app.redirect("index")
@@ -156,7 +155,6 @@ def discord_link_confirm():
             )
             return app.redirect("index")
 
-    form = DiscordLinkForm()
 
     if not form.validate_on_submit():
         return app.render(

--- a/app/routes/games.py
+++ b/app/routes/games.py
@@ -17,8 +17,8 @@ class SearchForm(Form):
 
 
 @app.route("/games/")
-def games():
-    form = SearchForm(flask.request.args)
+def games(form: SearchForm):
+    # form = SearchForm(flask.request.args)
     form.platform.data = form.platform.data or "Arcade"
     games_ = service.get_all(sort="name")
     for game in games_:

--- a/app/routes/games.py
+++ b/app/routes/games.py
@@ -18,7 +18,6 @@ class SearchForm(Form):
 
 @app.route("/games/")
 def games(form: SearchForm):
-    # form = SearchForm(flask.request.args)
     form.platform.data = form.platform.data or "Arcade"
     games_ = service.get_all(sort="name")
     for game in games_:

--- a/app/routes/user/listing.py
+++ b/app/routes/user/listing.py
@@ -19,8 +19,8 @@ class SearchForm(Form):
 
 
 @app.get("/users/")
-def users():
-    form = SearchForm(flask.request.args)
+def users(form: SearchForm):
+    # form = SearchForm(flask.request.args)
 
     if form.game.data == "all":
         form.game.data = None

--- a/app/routes/user/listing.py
+++ b/app/routes/user/listing.py
@@ -20,7 +20,6 @@ class SearchForm(Form):
 
 @app.get("/users/")
 def users(form: SearchForm):
-    # form = SearchForm(flask.request.args)
 
     if form.game.data == "all":
         form.game.data = None

--- a/app/routes/user/listing.py
+++ b/app/routes/user/listing.py
@@ -1,4 +1,3 @@
-import flask
 from wtforms import SelectField, StringField
 
 from app import app

--- a/app/routes/user/login.py
+++ b/app/routes/user/login.py
@@ -21,8 +21,8 @@ class LoginForm(Form):
 
 
 @app.route("/login/")
-def login():
-    form = LoginForm()
+def login(form: LoginForm):
+    # form = LoginForm()
 
     def get():
         return app.render(

--- a/app/routes/user/login.py
+++ b/app/routes/user/login.py
@@ -22,7 +22,6 @@ class LoginForm(Form):
 
 @app.route("/login/")
 def login(form: LoginForm):
-    # form = LoginForm()
 
     def get():
         return app.render(

--- a/app/routes/user/register.py
+++ b/app/routes/user/register.py
@@ -7,11 +7,11 @@ from app.services import user as service
 class RegisterForm(Form):
     login = LoginField()
     password = PasswordField(validators=[DataRequired()])
-
+    
 
 @app.route("/register/")
-def register():
-    form = RegisterForm()
+def register(form: RegisterForm):
+    # form = RegisterForm()
     if not form.validate_on_submit():
         return app.render(
             "users/register", form=form, page="login", title="Inscription"

--- a/app/routes/user/register.py
+++ b/app/routes/user/register.py
@@ -7,7 +7,7 @@ from app.services import user as service
 class RegisterForm(Form):
     login = LoginField()
     password = PasswordField(validators=[DataRequired()])
-    
+
 
 @app.route("/register/")
 def register(form: RegisterForm):

--- a/app/routes/user/register.py
+++ b/app/routes/user/register.py
@@ -11,7 +11,6 @@ class RegisterForm(Form):
 
 @app.route("/register/")
 def register(form: RegisterForm):
-    # form = RegisterForm()
     if not form.validate_on_submit():
         return app.render(
             "users/register", form=form, page="login", title="Inscription"

--- a/app/routes/user/settings.py
+++ b/app/routes/user/settings.py
@@ -45,7 +45,6 @@ class EditProfileForm(Form):
 @app.route("/settings/")
 @service.authenticated
 def settings(form: EditProfileForm):
-    # form = EditProfileForm()
 
     if form.logout.data or form.unlink_discord.data:
         form._csrf.validate_csrf_token(form, form.csrf_token)

--- a/app/routes/user/settings.py
+++ b/app/routes/user/settings.py
@@ -44,8 +44,8 @@ class EditProfileForm(Form):
 
 @app.route("/settings/")
 @service.authenticated
-def settings():
-    form = EditProfileForm()
+def settings(form: EditProfileForm):
+    # form = EditProfileForm()
 
     if form.logout.data or form.unlink_discord.data:
         form._csrf.validate_csrf_token(form, form.csrf_token)


### PR DESCRIPTION
This PR suggests a solution for issue [#1](https://github.com/asso-msn/msn-web/issues/1).

### Description of Change
This PR modifies the `route` method in the custom Flask application class to automatically inject FlaskForm instances into view function arguments based on type annotations like FastAPI.
With this enhancement:
- Forms are automatically instantiated and passed to the corresponding view function, simplifying form handling.
- The HTTP method (GET or POST) determines whether flask.request.args or flask.request.form is used as the data source for the form.
### Testing
Tested manually on pages except those related to discord, the site functions as before.